### PR TITLE
SR system byte M bit is always zero for 68000/68010

### DIFF
--- a/TG68KdotC_Kernel.vhd
+++ b/TG68KdotC_Kernel.vhd
@@ -1342,6 +1342,7 @@ PROCESS (clk, Reset, FlagsSR, last_data_read, OP2out, exec)
 					FC(2) <= '1';
 				END IF;	
 				IF cpu(1)='0' THEN
+					FlagsSR(4) <= '0';
 					FlagsSR(6) <= '0';
 				END IF;
 				FlagsSR(3) <= '0';


### PR DESCRIPTION
Was already fixed in MiST core.

Pushes EORSR.W & ORSR.W cputest from 16386 to 131074 (as with 68020).
