### PR TITLE
Fix cputest ILLEGAL.B

### DIFF
--- a/TG68KdotC_Kernel.vhd
+++ b/TG68KdotC_Kernel.vhd
@@ -2590,8 +2590,8 @@ PROCESS (clk, cpu, OP1out, OP2out, opcode, exe_condition, nextpass, micro_state,
 					END CASE;
 				END IF;	
 --					
----- 0101 ----------------------------------------------------------------------------		
-			WHEN "0101" => 								--subq, addq	
+---- 0101 ----------------------------------------------------------------------------
+			WHEN "0101" => 								--subq, addq
 					IF opcode(7 downto 6)="11" THEN --dbcc
 						IF opcode(5 downto 3)="001" THEN --dbcc
 							IF decodeOPC='1' THEN
@@ -2605,13 +2605,13 @@ PROCESS (clk, cpu, OP1out, OP2out, opcode, exe_condition, nextpass, micro_state,
 									IF decodeOPC='1' THEN
 										IF opcode(0)='1' THEN			--long
 											set(longaktion) <= '1';
-										END IF;	
+										END IF;
 										next_micro_state <= nop;
 									END IF;
-								ELSE 	
+								ELSE
 									IF decodeOPC='1' THEN
 										setstate <= "01";
-									END IF;	
+									END IF;
 								END IF;
 								trap_trapcc<='1';
 								IF exe_condition='1' AND decodeOPC='0' THEN
@@ -2630,26 +2630,32 @@ PROCESS (clk, cpu, OP1out, OP2out, opcode, exe_condition, nextpass, micro_state,
 							IF cpu(0)='1' AND state="10" THEN
 								skipFetch <= '1';
 							END IF;
-							IF opcode(5 downto 4)="00" THEN					
+							IF opcode(5 downto 4)="00" THEN
 								set_exec(Regwrena) <= '1';
 							END IF;
 						END IF;
 					ELSE					--addq, subq
-						ea_build_now <= '1';
-						IF opcode(5 downto 3)="001" THEN	
-							set(no_Flags) <= '1';
+						IF opcode(7 downto 3)/="00001" AND
+						   (opcode(5 downto 3)/="111" OR opcode(2 downto 1)="00") THEN --ea illegal modes
+							ea_build_now <= '1';
+							IF opcode(5 downto 3)="001" THEN
+								set(no_Flags) <= '1';
+							END IF;
+							IF opcode(8)='1' THEN
+								set(addsub) <= '1';
+							END IF;
+							write_back <= '1';
+							set_exec(opcADDQ) <= '1';
+							set_exec(opcADD) <= '1';
+							set_exec(ea_data_OP1) <= '1';
+							IF opcode(5 downto 4)="00" THEN
+								set_exec(Regwrena) <= '1';
+							END IF;
+						ELSE
+							trap_illegal <= '1';
+							trapmake <= '1';
 						END IF;
-						IF opcode(8)='1' THEN
-							set(addsub) <= '1';
-						END IF;
-						write_back <= '1';
-						set_exec(opcADDQ) <= '1';
-						set_exec(opcADD) <= '1';
-						set_exec(ea_data_OP1) <= '1';
-						IF opcode(5 downto 4)="00" THEN					
-							set_exec(Regwrena) <= '1';
-						END IF;
-					END IF;	
+					END IF;
 --				
 ---- 0110 ----------------------------------------------------------------------------		
 			WHEN "0110" =>				--bra,bsr,bcc

--- a/TG68KdotC_Kernel.vhd
+++ b/TG68KdotC_Kernel.vhd
@@ -3060,13 +3060,87 @@ PROCESS (clk, cpu, OP1out, OP2out, opcode, exe_condition, nextpass, micro_state,
 						set_exec(Regwrena) <= '1';
 					END IF;
 				END IF;
+--				
+---- 1111 ----------------------------------------------------------------------------		
+			WHEN "1111" =>
+				IF cpu(1)='1' AND opcode(8 downto 6)="100" THEN --cpSAVE
+					IF opcode(5 downto 4)/="00" AND opcode(5 downto 3)/="011" AND
+					   (opcode(5 downto 3)/="111" OR opcode(2 downto 1)="00") THEN --ea illegal modes
+						IF opcode(11 downto 9)/="000" THEN
+							IF SVmode='1' THEN
+								IF opcode(5)='0' AND opcode(5 downto 4)/="01" THEN
+									--never reached according to cputest?!
+									--cpSAVE not implemented
+									trap_illegal <= '1';
+									trapmake <= '1';
+								ELSE
+									trap_1111 <= '1';
+									trapmake <= '1';
+								END IF;
+							ELSE
+								trap_priv <= '1';
+								trapmake <= '1';
+							END IF;
+						ELSE
+							IF SVmode='1' THEN
+								trap_1111 <= '1';
+								trapmake <= '1';
+							ELSE
+								trap_priv <= '1';
+								trapmake <= '1';
+							END IF;
+						END IF;
+					ELSE
+						trap_1111 <= '1';
+						trapmake <= '1';
+					END IF;
+				ELSIF cpu(1)='1' AND opcode(8 downto 6)="101" THEN --cpRESTORE
+					IF opcode(5 downto 4)/="00" AND opcode(5 downto 3)/="100" AND
+					   (opcode(5 downto 3)/="111" OR (opcode(2 downto 1)/="11" AND
+					   opcode(2 downto 0)/="101")) THEN --ea illegal modes
+						IF opcode(5 downto 1)/="11110" THEN
+							IF opcode(11 downto 9)="001" OR opcode(11 downto 9)="010" THEN
+								IF SVmode='1' THEN
+									IF opcode(5 downto 3)="101" THEN
+										--cpRESTORE not implemented
+										trap_illegal <= '1';
+										trapmake <= '1';
+									ELSE
+										trap_1111 <= '1';
+										trapmake <= '1';
+									END IF;
+								ELSE
+									trap_priv <= '1';
+									trapmake <= '1';
+								END IF;
+							ELSE
+								IF SVmode='1' THEN
+									trap_1111 <= '1';
+									trapmake <= '1';
+								ELSE
+									trap_priv <= '1';
+									trapmake <= '1';
+								END IF;
+							END IF;
+						ELSE
+							trap_1111 <= '1';
+							trapmake <= '1';
+						END IF;
+					ELSE
+						trap_1111 <= '1';
+						trapmake <= '1';
+					END IF;
+				ELSE
+					trap_1111 <= '1';
+					trapmake <= '1';
+				END IF;
 --							
 ----      ----------------------------------------------------------------------------		
-			WHEN OTHERS =>	
-				trap_1111 <= '1';
+			WHEN OTHERS =>
+				trap_illegal <= '1';
 				trapmake <= '1';
 
-		END CASE;		
+		END CASE;
 
 -- use for AND, OR, EOR, CMP
 		IF build_logical='1' THEN

--- a/TG68KdotC_Kernel.vhd
+++ b/TG68KdotC_Kernel.vhd
@@ -2690,11 +2690,16 @@ PROCESS (clk, cpu, OP1out, OP2out, opcode, exe_condition, nextpass, micro_state,
 				
 -- 0111 ----------------------------------------------------------------------------		
 			WHEN "0111" =>				--moveq
+				IF opcode(8)='0' THEN
 					datatype <= "10";		--Long
 					set_exec(Regwrena) <= '1';
 					set_exec(opcMOVEQ) <= '1';
 					set_exec(opcMOVE) <= '1';
 					dest_hbits <= '1';
+				ELSE
+					trap_illegal <= '1';
+					trapmake <= '1';
+				END IF;
 				
 ---- 1000 ----------------------------------------------------------------------------		
 			WHEN "1000" => 								--or	


### PR DESCRIPTION
This fixes the ILLEGAL.B cputest (for 68000 & 68020 - 68010 not tested).

```
CPUlvl=0, Mask=00ffffff Code=00340000 SP=0037fbc0 ISP=00380000
Low: 00000000-00008000 High: 00ff8000-01000000
Test: 00300000-00380000 Safe: ffffffff-ffffffff
ILLEGAL.B:
data/68000/ILLEGAL.B/0000.dat. 0...
data/68000/ILLEGAL.B/0001.dat. 34878...
All tests complete (total 34878).
```

```
CPUlvl=2, Mask=ffffffff Code=00340000 SP=0037fbc0 ISP=00380000
Low: 00000000-00008000 High: ffffffff-ffffffff
Test: 00300000-00380000 Safe: ffffffff-ffffffff
ILLEGAL.B:
data/68020/ILLEGAL.B/0000.dat. 0...
data/68020/ILLEGAL.B/0001.dat. 35826...
All tests complete (total 35826).
```

One commit per opcode group. Generally just some IFs to check for illegal size and ea modes.
"Fix" for opcode group b1111 (cpRESTORE, cpSAVE) is weird and was a bit of trial and error.

Commits are best viewed with option 'ignore whitespaces' (usually option -w for command line tools, or add ?w=1 to github URLs)

- https://github.com/TobiFlex/TG68K.C/commit/0461edd8b768f4d94bef17814aa5076375dd2964?w=1
- https://github.com/TobiFlex/TG68K.C/commit/ae95cb36478daec7c53be0f2ddc561f130022ea3?w=1
- https://github.com/TobiFlex/TG68K.C/commit/e9d2fdaeadb218e00b5dcedeba47c1a91570bf7b?w=1
- https://github.com/TobiFlex/TG68K.C/commit/0bc517d3a71715c07475ced97e20d003f90cf445?w=1
- https://github.com/TobiFlex/TG68K.C/commit/5859bf3e23985803e2e981d7de50b505309b610a?w=1
- https://github.com/TobiFlex/TG68K.C/commit/bec6548f540437627bb67ca7f1f26ac2491ac4c5?w=1
- https://github.com/TobiFlex/TG68K.C/commit/9c0deefe5f6b707622788a6628709b3b88ac5591?w=1
- https://github.com/TobiFlex/TG68K.C/commit/10f1f6007fc2e787c401c095c8744f5c19f4325e?w=1
- https://github.com/TobiFlex/TG68K.C/commit/e3e21d1f317d593d6430cc6814c121c5b1530154?w=1
- https://github.com/TobiFlex/TG68K.C/commit/a3f1969313af0b310c5fe64913ed570089e2190f?w=1
- https://github.com/TobiFlex/TG68K.C/commit/eab3704ea4471297c2a5157eefaa2ec0fee4ba4a?w=1