### PR TITLE
Add a longword signal.  Aids in combining the two halves of a 32-bit write and making use of RAM bursts.

### DIFF
--- a/TG68KdotC_Kernel.vhd
+++ b/TG68KdotC_Kernel.vhd
@@ -124,6 +124,7 @@ entity TG68KdotC_Kernel is
 		nUDS						: out std_logic;
 		nLDS						: out std_logic;
 		busstate					: out std_logic_vector(1 downto 0);	-- 00-> fetch code 10->read data 11->write data 01->no memaccess
+		longword					: out std_logic;
 		nResetOut				: out std_logic;
 		FC							: out std_logic_vector(2 downto 0);
 		clr_berr					: out std_logic;
@@ -408,6 +409,9 @@ ALU: TG68K_ALU
 		ALUout => ALUout						--: buffer std_logic_vector(31 downto 0)
 	);
 
+	-- AMR - let the parent module know this is a longword access.  (Easy way to enable burst writes.)
+	longword <= not memmaskmux(3);
+	
 	long_start_alu <= to_bit(NOT memmaskmux(3));
 	execOPC_ALU <= execOPC OR exec(alu_exec);
 	process (memmaskmux)


### PR DESCRIPTION
I added this as an experiment some months ago when implementing RTG on Minimig.  I wanted to improve the performance of writing to the framebuffer by using burst writes for 32-bit accesses.  It seems to work reliably without unfortunate side-effects.